### PR TITLE
fix: extend connection timeout

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -258,7 +258,7 @@ export const handler = async (
       user: secretValues.username,
       password: secretValues.password,
       database: database,
-      connectionTimeoutMillis: 2000, // return an error if a connection could not be established within 2 seconds
+      connectionTimeoutMillis: 30000, // return an error if a connection could not be established within 30 seconds
     }
     //console.debug ("PARAMS", params)
     const pg_client = new Client(params)


### PR DESCRIPTION
Fixes #7

Agree with @moltar - the timeout is very very low and can cause timeout exceptions that could be avoided by just bumping the time.

Since the lambda has 300 seconds to run, a maximum of 30 seconds to connect seems reasonable.