### PR TITLE
feat: extra database connection properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,24 @@ const provider = new Provider(this, "Provider", {
 })
 ```
 
+### Additional connection options
+
+Additional options can be passed to the provider.
+The available options can be found [here](https://node-postgres.com/apis/client).
+
+> Keep in mind that certain properties (e.g., username, password, host) are forcibly by this resource. If you provide them in `connectionProps`, they will be ignored.
+
+```ts
+const provider = new Provider(this, "Provider", {
+  vpc: vpc,
+  instance: instance,
+  secret: cluster.secret!,
+  connectionProps: {
+    ssl: true
+  }
+})
+```
+
 ## Roles
 
 Create a postgres role (user) for a cluster as follows:

--- a/src/database.ts
+++ b/src/database.ts
@@ -56,6 +56,7 @@ export class Database extends CustomResource implements IDatabase {
         ResourceId: props.databaseName,
         SecretArn: props.provider.secret.secretArn,
         Owner: props.owner?.roleName,
+        ConnectionProps: props.provider.connectionProps,
       },
     })
     this.node.addDependency(props.provider)

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -10,7 +10,7 @@ import {
 } from "aws-lambda"
 import { backOff } from "exponential-backoff"
 import { format } from "node-pg-format"
-import { Client } from "pg"
+import { Client, ClientConfig } from "pg"
 import { RdsSqlResource } from "./enum"
 
 interface CustomResourceResponse {
@@ -247,6 +247,7 @@ export const handler = async (
   const resource: RdsSqlResource = event.ResourceProperties.Resource
   const resourceId = event.ResourceProperties.ResourceId
   const databaseName = event.ResourceProperties.DatabaseName
+  const connectionProps = (event.ResourceProperties.ConnectionProps || {}) as ClientConfig
 
   if (!Object.keys(jumpTable).includes(event.ResourceProperties.Resource)) {
     throw `Resource type '${resource}' not recognised.`
@@ -310,7 +311,7 @@ export const handler = async (
     } else {
       database = databaseName ?? secretValues.dbname // connect to given database if possible, else to database mentioned in secret
     }
-    const params = {
+    const baseParams = {
       host: secretValues.host,
       port: secretValues.port,
       user: secretValues.username,
@@ -318,6 +319,9 @@ export const handler = async (
       database: database,
       connectionTimeoutMillis: 2000, // return an error if a connection could not be established within 2 seconds
     }
+    // merge the base params with the new params provided
+    // directly to the resource
+    const params = { ...connectionProps, ...baseParams }
     log(
       `Connecting to host ${params.host}: ${params.port}, database ${params.database} as ${params.user}`
     )

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -13,6 +13,7 @@ import {
 import { ISecret } from "aws-cdk-lib/aws-secretsmanager"
 import * as customResources from "aws-cdk-lib/custom-resources"
 import { Construct } from "constructs"
+import { ClientConfig } from "pg"
 
 export interface RdsSqlProps {
   /**
@@ -67,6 +68,14 @@ export interface RdsSqlProps {
    * @default - empty
    */
   readonly functionProps?: NodejsFunctionProps
+
+  /**
+   * Additional properties when establishing the database sql
+   * connection.
+   *
+   * @default - empty object
+   */
+  readonly connectionProps?: any
 }
 
 export class Provider extends Construct {
@@ -74,11 +83,13 @@ export class Provider extends Construct {
   public readonly secret: ISecret
   public readonly handler: IFunction
   public readonly cluster: IServerlessCluster | IDatabaseCluster | IDatabaseInstance
+  public readonly connectionProps: ClientConfig
 
   constructor(scope: Construct, id: string, props: RdsSqlProps) {
     super(scope, id)
     this.secret = props.secret
     this.cluster = props.cluster
+    this.connectionProps = props.connectionProps
 
     const functionName = "RdsSql" + slugify("28b9e791-af60-4a33-bca8-ffb6f30ef8c5")
     this.handler =

--- a/src/role.custom-resource.ts
+++ b/src/role.custom-resource.ts
@@ -53,6 +53,7 @@ export class Role extends CustomResource {
         SecretArn: props.provider.secret.secretArn,
         PasswordArn: props.passwordArn,
         DatabaseName: props.database ? props.database.databaseName : props.databaseName,
+        ConnectionProps: props.provider.connectionProps,
       },
     })
     this.node.addDependency(props.provider)

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -34,6 +34,7 @@ export class Schema extends CustomResource {
         ResourceId: props.schemaName,
         SecretArn: props.provider.secret.secretArn,
         DatabaseName: props.database ? props.database.databaseName : undefined,
+        ConnectionProps: props.provider.connectionProps,
       },
     })
     this.node.addDependency(props.provider)

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -38,6 +38,7 @@ export class Sql extends CustomResource {
         DatabaseName: props.database ? props.database.databaseName : undefined,
         Statement: props.statement,
         Rollback: props.rollback,
+        ConnectionProps: props.provider.connectionProps,
       },
     })
     this.node.addDependency(props.provider)


### PR DESCRIPTION
Added an option to set extra client properties when connecting to the database. This is primarily needed so that SSL/TLS can be used to connect to the database.

This change should be backwards compatible as well as if no props are set, it just won't set anything and behave exactly as it does now.

Fixes #28

I wasn't sure of a good way to test this because I couldn't find a way to get the PostgreSQL testcontainer to use TLS.

Note: this doesn't solve the issue of custom CA's that was discussed in #28, but at least we can turn SSL/TLS on. It's a start...