### PR TITLE
fix: use dbInstanceIdentifier in Role secret for DatabaseInstance providers

### DIFF
--- a/src/role.ts
+++ b/src/role.ts
@@ -192,15 +192,17 @@ export class Role extends Construct {
       }
 
       // For RDS/Aurora clusters and instances, get endpoint details
-      const host = (props.provider.cluster as IDatabaseCluster).clusterEndpoint
+      const isCluster = !!(props.provider.cluster as IDatabaseCluster).clusterEndpoint
+
+      const host = isCluster
         ? (props.provider.cluster as IDatabaseCluster).clusterEndpoint.hostname
         : (props.provider.cluster as IDatabaseInstance).instanceEndpoint.hostname
 
-      const port = (props.provider.cluster as IDatabaseCluster).clusterEndpoint
+      const port = isCluster
         ? (props.provider.cluster as IDatabaseCluster).clusterEndpoint.port
         : (props.provider.cluster as IDatabaseInstance).instanceEndpoint.port
 
-      const identifier = (props.provider.cluster as IDatabaseCluster).clusterIdentifier
+      const identifier = isCluster
         ? (props.provider.cluster as IDatabaseCluster).clusterIdentifier
         : (props.provider.cluster as IDatabaseInstance).instanceIdentifier
 
@@ -210,8 +212,9 @@ export class Role extends Construct {
 
       // Create secret only for password auth (not IAM auth)
       if (!useIamAuth) {
+        const identifierKey = isCluster ? "dbClusterIdentifier" : "dbInstanceIdentifier"
         const secretTemplate = {
-          dbClusterIdentifier: identifier,
+          [identifierKey]: identifier,
           engine: props.provider.engine,
           host: host,
           port: port,
@@ -235,8 +238,9 @@ export class Role extends Construct {
 
       // Create Parameters if parameterPrefix is provided (for both password and IAM auth)
       if (props.parameterPrefix) {
+        const identifierKey = isCluster ? "dbClusterIdentifier" : "dbInstanceIdentifier"
         const paramData: Record<string, string | number> = {
-          dbClusterIdentifier: identifier,
+          [identifierKey]: identifier,
           engine: props.provider.engine,
           host: host,
           port: port,

--- a/test/instance-stack.test.ts
+++ b/test/instance-stack.test.ts
@@ -183,6 +183,70 @@ test("vpcSubnet selection can be specified", () => {
   }).toThrow()
 })
 
+test("instance role secret uses dbInstanceIdentifier not dbClusterIdentifier", () => {
+  const app = new cdk.App()
+  const stack = new cdk.Stack(app, "TestStack", {
+    env: {
+      account: "123456789",
+      region: "us-east-1",
+    },
+  })
+  const vpc = new ec2.Vpc(stack, "Vpc", {
+    subnetConfiguration: [
+      {
+        cidrMask: 28,
+        name: "rds",
+        subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
+      },
+    ],
+  })
+
+  const instance = new rds.DatabaseInstance(stack, "Instance", {
+    vpc,
+    vpcSubnets: {
+      subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
+    },
+    engine: rds.DatabaseInstanceEngine.postgres({
+      version: rds.PostgresEngineVersion.VER_15,
+    }),
+    databaseName: "example",
+    credentials: rds.Credentials.fromGeneratedSecret("admin"),
+    instanceType: ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.MICRO),
+  })
+
+  const provider = new Provider(stack, "Provider", {
+    vpc: vpc,
+    cluster: instance,
+    secret: instance.secret!,
+  })
+
+  new Role(stack, "Role", {
+    provider: provider,
+    roleName: "myrole",
+    databaseName: "mydb",
+  })
+
+  const template = Template.fromStack(stack)
+
+  // Should use dbInstanceIdentifier (not dbClusterIdentifier) for instances
+  template.hasResourceProperties("AWS::SecretsManager::Secret", {
+    GenerateSecretString: {
+      SecretStringTemplate: {
+        "Fn::Join": [
+          "",
+          // eslint-disable-next-line quotes
+          Match.arrayWith([Match.stringLikeRegexp('"dbInstanceIdentifier"')]),
+        ],
+      },
+    },
+  })
+
+  // Should NOT have dbClusterIdentifier for instances
+  const resources = template.findResources("AWS::SecretsManager::Secret")
+  const secretValues = JSON.stringify(resources)
+  expect(secretValues).not.toContain("dbClusterIdentifier")
+})
+
 test("mysql database instance engine is set in secret", () => {
   const app = new cdk.App()
   const stack = new cdk.Stack(app, "TestStack", {

--- a/test/instance-stack.test.ts
+++ b/test/instance-stack.test.ts
@@ -211,7 +211,10 @@ test("instance role secret uses dbInstanceIdentifier not dbClusterIdentifier", (
     }),
     databaseName: "example",
     credentials: rds.Credentials.fromGeneratedSecret("admin"),
-    instanceType: ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.MICRO),
+    instanceType: ec2.InstanceType.of(
+      ec2.InstanceClass.BURSTABLE3,
+      ec2.InstanceSize.MICRO
+    ),
   })
 
   const provider = new Provider(stack, "Provider", {


### PR DESCRIPTION
When a Provider is configured with a DatabaseInstance (not a cluster), the generated Role secret now correctly uses `dbInstanceIdentifier` as the key instead of always using `dbClusterIdentifier`.

Fixes #54

Generated with [Claude Code](https://claude.ai/code)