### PR TITLE
fix: use %L instead of '%s' in pg_database existence check

### DIFF
--- a/lambda/engine.postgresql.ts
+++ b/lambda/engine.postgresql.ts
@@ -53,7 +53,7 @@ export class PostgresqlEngine extends AbstractEngine {
         resourceId
       ),
       pgFormat(
-        "DO $$BEGIN\nIF EXISTS (select from pg_database WHERE datname = '%s') THEN alter database %I owner to %I; END IF;\nEND$$;",
+        "DO $$BEGIN\nIF EXISTS (select from pg_database WHERE datname = %L) THEN alter database %I owner to %I; END IF;\nEND$$;",
         resourceId,
         resourceId,
         masterUser


### PR DESCRIPTION
Why: interpolating a resource identifier into a SQL string literal via pgFormat's %s specifier leaves the value unescaped inside the quotes, enabling SQL injection if the identifier contains a single quote. %L properly escapes the literal.

Fixes #