### PR TITLE
feat: enable pypi publish (#52)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,3 +131,45 @@ jobs:
         run: cd .repo && pnpm exec projen package:js
       - name: Collect js artifact
         run: mv .repo/dist dist
+  package-python:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: ${{ !needs.build.outputs.self_mutation_happened }}
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          package-manager-cache: "false"
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-artifact
+          path: dist
+      - name: Restore build artifact permissions
+        run: cd dist && setfacl --restore=permissions-backup.acl
+        continue-on-error: true
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.32.1
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          path: .repo
+      - name: Install Dependencies
+        run: cd .repo && pnpm i --frozen-lockfile
+      - name: Extract build artifact
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+      - name: Move build artifact out of the way
+        run: mv dist dist.old
+      - name: Create python artifact
+        run: cd .repo && pnpm exec projen package:python
+      - name: Collect python artifact
+        run: mv .repo/dist dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
     needs:
       - release
       - release_npm
+      - release_pypi
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -136,3 +137,49 @@ jobs:
           NPM_CONFIG_PROVENANCE: "true"
           NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm
+  release_pypi:
+    name: Publish to PyPI
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          package-manager-cache: "false"
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-artifact
+          path: dist
+      - name: Restore build artifact permissions
+        run: cd dist && setfacl --restore=permissions-backup.acl
+        continue-on-error: true
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.32.1
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          path: .repo
+      - name: Install Dependencies
+        run: cd .repo && pnpm i --frozen-lockfile
+      - name: Extract build artifact
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+      - name: Move build artifact out of the way
+        run: mv dist dist.old
+      - name: Create python artifact
+        run: cd .repo && pnpm exec projen package:python
+      - name: Collect python artifact
+        run: mv .repo/dist dist
+      - name: Release
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+        run: npx -p publib@latest publib-pypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v6
@@ -180,6 +181,5 @@ jobs:
         run: mv .repo/dist dist
       - name: Release
         env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          PYPI_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-pypi

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,6 +8,7 @@ queue_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=package-js
+      - status-success=package-python
     merge_method: squash
     commit_message_template: |-
       {{ title }} (#{{ number }})
@@ -23,5 +24,6 @@ pull_request_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=package-js
+      - status-success=package-python
 merge_queue:
   max_parallel_checks: 1

--- a/.npmignore
+++ b/.npmignore
@@ -9,6 +9,7 @@ src/handler/handler.js
 *~
 .claude/hooks/.edited
 /lambda/
+!pnpm-lock.yaml
 /.projen/
 /test-reports/
 junit.xml

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -231,6 +231,9 @@
       "steps": [
         {
           "spawn": "package:js"
+        },
+        {
+          "spawn": "package:python"
         }
       ]
     },
@@ -240,6 +243,15 @@
       "steps": [
         {
           "exec": "jsii-pacmak -v --pack-command \"pnpm pack\" --target js"
+        }
+      ]
+    },
+    "package:python": {
+      "name": "package:python",
+      "description": "Create python language bindings",
+      "steps": [
+        {
+          "exec": "jsii-pacmak -v --pack-command \"pnpm pack\" --target python"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -103,6 +103,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   publishToPypi: {
     distName: "cdk-rds-sql",
     module: "cdk_rds_sql",
+    trustedPublishing: true,
   },
 })
 if (project.eslint) {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -80,7 +80,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     prettier: true,
   },
   gitignore: tmpDirectories,
-  npmignore: [...tmpDirectories, "/lambda/"],
+  npmignore: [...tmpDirectories, "/lambda/", "!pnpm-lock.yaml"],
   docgen: false,
   workflowNodeVersion: "24.x",
   deps: ["@types/aws-lambda"],
@@ -100,6 +100,10 @@ const project = new awscdk.AwsCdkConstructLibrary({
   ],
   keywords: ["aws", "aws-cdk", "rds", "aurora", "postgres", "mysql", "dsql"],
   minMajorVersion: 1,
+  publishToPypi: {
+    distName: "cdk-rds-sql",
+    module: "cdk_rds_sql",
+  },
 })
 if (project.eslint) {
   project.eslint.addRules({

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "package": "projen package",
     "package-all": "projen package-all",
     "package:js": "projen package:js",
+    "package:python": "projen package:python",
     "post-compile": "projen post-compile",
     "post-upgrade": "projen post-upgrade",
     "pre-compile": "projen pre-compile",
@@ -173,7 +174,12 @@
   "stability": "stable",
   "jsii": {
     "outdir": "dist",
-    "targets": {},
+    "targets": {
+      "python": {
+        "distName": "cdk-rds-sql",
+        "module": "cdk_rds_sql"
+      }
+    },
     "tsc": {
       "outDir": "lib",
       "rootDir": "src"

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -299,6 +299,7 @@ export class Provider extends Construct implements IProvider {
 
     const fn = new lambda.NodejsFunction(scope, id, {
       ...props.functionProps,
+      depsLockFilePath: path.join(__dirname, "..", "pnpm-lock.yaml"),
       // Only configure VPC for traditional RDS
       ...(isDsql
         ? {}


### PR DESCRIPTION
provider.ts: NodejsFunction walks up from process.cwd() to find a lock file. Python CDK projects have none, so the search fails. Explicit depsLockFilePath fixes this by resolving relative to the library's own __dirname instead.

.npmignore: pnpm-lock.yaml must be in the published package so the path is valid when jsii extracts the tarball to a temp directory at runtime.

The rest of the changes are generated by projen, once publishToPypi was enabled to `.projenrc.ts`

Fixes #52 

Important: in order for the publish to succeed, you will need to:

 - create a PyPI account
 - generate a PyPI API token
 - create in the repository secrets:
      - TWINE_USERNAME=__token__
      - TWINE_PASSWORD=pypi-...

Otherwise the publish workflow will fail