### PR TITLE
fix: refresh password parameter on secret updates

### DIFF
--- a/lambda/types.ts
+++ b/lambda/types.ts
@@ -67,6 +67,8 @@ export interface ParameterPasswordProperties extends CommonProperties {
   readonly Resource: RdsSqlResource.PARAMETER_PASSWORD
   readonly PasswordArn: string
   readonly ParameterName: string
+  /** Ignored by the handler; forces CloudFormation updates when secret config changes. */
+  readonly SyncTrigger?: Record<string, unknown>
 }
 
 // Union type of all resource properties

--- a/src/role.ts
+++ b/src/role.ts
@@ -97,7 +97,7 @@ class Parameters extends Construct {
       secretArn: string
       parameterPrefix: string
       passwordArn?: string
-      passwordSecret?: Construct
+      passwordSecret?: Secret
       passwordSyncTrigger?: Record<string, unknown>
       providerServiceToken: string
       paramData: Record<string, string | number>

--- a/src/role.ts
+++ b/src/role.ts
@@ -65,8 +65,8 @@ export interface RoleProps {
    * `parameterPrefix`, so make sure the prefix ends with a slash if
    *  you have your parameter names slash separated.
    *
-   * Note that the password from the secret is copied just once, they
-   * are not kept in sync.
+   * The password parameter is refreshed when CloudFormation updates the
+   * generated secret resource.
    *
    * @default - credentials are only stored in Secrets Manager
    */
@@ -97,6 +97,8 @@ class Parameters extends Construct {
       secretArn: string
       parameterPrefix: string
       passwordArn?: string
+      passwordSecret?: Construct
+      passwordSyncTrigger?: Record<string, unknown>
       providerServiceToken: string
       paramData: Record<string, string | number>
     }
@@ -124,9 +126,13 @@ class Parameters extends Construct {
           Resource: RdsSqlResource.PARAMETER_PASSWORD,
           PasswordArn: props.passwordArn,
           ParameterName: passwordParameterName,
+          SyncTrigger: props.passwordSyncTrigger,
         },
       })
       password_parameter.node.addDependency(props.provider)
+      if (props.passwordSecret) {
+        password_parameter.node.addDependency(props.passwordSecret)
+      }
 
       const paramArn = `arn:${Stack.of(this).partition}:ssm:${Stack.of(this).region}:${
         Stack.of(this).account
@@ -179,6 +185,8 @@ export class Role extends Construct {
     // Skip secret creation for DSQL (always uses IAM auth) or when enableIamAuth is true
     const useIamAuth =
       props.enableIamAuth || props.provider.engine === DatabaseEngine.DSQL
+    let passwordSyncTrigger: Record<string, unknown> | undefined
+    let passwordSecret: Secret | undefined
 
     // For non-DSQL providers, we need cluster info for secrets and/or parameters
     if (props.provider.engine !== DatabaseEngine.DSQL) {
@@ -209,7 +217,6 @@ export class Role extends Construct {
       const databaseName = props.database
         ? props.database.databaseName
         : props.databaseName
-
       // Create secret only for password auth (not IAM auth)
       if (!useIamAuth) {
         const identifierKey = isCluster ? "dbClusterIdentifier" : "dbInstanceIdentifier"
@@ -221,19 +228,22 @@ export class Role extends Construct {
           username: props.roleName,
           dbname: databaseName,
         }
+        const generateSecretString = {
+          passwordLength: 30, // Oracle password cannot have more than 30 characters
+          secretStringTemplate: JSON.stringify(secretTemplate),
+          generateStringKey: "password",
+          excludeCharacters: " %+~`#$&*()|[]{}:;<>?!'/@\"\\",
+        }
+        passwordSyncTrigger = generateSecretString
 
-        this.secret = new Secret(this, "Secret", {
+        passwordSecret = new Secret(this, "Secret", {
           secretName: props.secretName,
           encryptionKey: props.encryptionKey,
           description: `Generated secret for ${props.provider.engine} role ${props.roleName}`,
-          generateSecretString: {
-            passwordLength: 30, // Oracle password cannot have more than 30 characters
-            secretStringTemplate: JSON.stringify(secretTemplate),
-            generateStringKey: "password",
-            excludeCharacters: " %+~`#$&*()|[]{}:;<>?!'/@\"\\",
-          },
+          generateSecretString,
           removalPolicy: RemovalPolicy.DESTROY,
         })
+        this.secret = passwordSecret
       }
 
       // Create Parameters if parameterPrefix is provided (for both password and IAM auth)
@@ -254,6 +264,8 @@ export class Role extends Construct {
           secretArn: props.provider.secret?.secretArn || "",
           parameterPrefix: props.parameterPrefix,
           passwordArn: this.secret?.secretArn, // undefined for IAM auth - skips password param
+          passwordSecret,
+          passwordSyncTrigger,
           providerServiceToken: props.provider.serviceToken,
           provider: props.provider,
           paramData,

--- a/test/cluster-stack.test.ts
+++ b/test/cluster-stack.test.ts
@@ -233,6 +233,11 @@ test("credentials stored in parameters", () => {
   template.hasResourceProperties("AWS::CloudFormation::CustomResource", {
     Resource: "parameter_password",
     ParameterName: "/my/params/path/password",
+    SyncTrigger: Match.objectLike({
+      generateStringKey: "password",
+      passwordLength: 30,
+      secretStringTemplate: Match.anyValue(),
+    }),
   })
 })
 


### PR DESCRIPTION
## Summary
- refresh the SSM password custom resource when the generated secret configuration changes
- add an explicit dependency so the SSM sync runs after the generated secret resource update
- assert the synthesized password parameter resource includes the sync trigger

## Why
Roles can optionally mirror generated credentials into SSM with parameterPrefix. The password is generated and owned by the Secrets Manager secret, while the Lambda-backed parameter_password custom resource copies that password into SSM.

When CloudFormation updates the generated secret resource, Secrets Manager may create a new password version. Before this change, the parameter_password custom resource had only stable properties such as PasswordArn and ParameterName, so CloudFormation did not update it. That left SSM with the old password while the managed secret held the current password.

This change ties the parameter_password custom resource to the generated secret configuration via a SyncTrigger property. If the generated secret resource changes, CloudFormation also updates the SSM copy resource, which reads the current secret password and overwrites the SSM parameter. The change does not itself rotate passwords or update database roles; it only keeps the SSM mirror aligned when a secret update occurs.

## Validation
- pre-commit hooks passed during commit, including synth, compile-project, and test
- tsc --noEmit -p tsconfig.dev.json
- git diff --check